### PR TITLE
Add prefix to all parts related to Reachability with EMS

### DIFF
--- a/Core/ConnectionWatchdog/EMSConnectionWatchdog.h
+++ b/Core/ConnectionWatchdog/EMSConnectionWatchdog.h
@@ -6,7 +6,7 @@
 
 @protocol EMSConnectionChangeListener
 
-- (void)connectionChangedToNetworkStatus:(NetworkStatus)networkStatus
+- (void)connectionChangedToNetworkStatus:(EMSNetworkStatus)networkStatus
                         connectionStatus:(BOOL)connected;
 
 @end
@@ -17,7 +17,7 @@
 
 - (instancetype)initWithReachability:(EMSReachability *)reachability;
 
-- (NetworkStatus)connectionState;
+- (EMSNetworkStatus)connectionState;
 
 - (BOOL)isConnected;
 

--- a/Core/ConnectionWatchdog/EMSConnectionWatchdog.m
+++ b/Core/ConnectionWatchdog/EMSConnectionWatchdog.m
@@ -26,7 +26,7 @@
     return self;
 }
 
-- (NetworkStatus)connectionState {
+- (EMSNetworkStatus)connectionState {
     return [self.reachability currentReachabilityStatus];
 }
 
@@ -53,7 +53,7 @@
 
 - (void)startObserving {
     __weak typeof(self) weakSelf = self;
-    self.notificationToken = [[NSNotificationCenter defaultCenter] addObserverForName:kReachabilityChangedNotification object:self.reachability queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *note) {
+    self.notificationToken = [[NSNotificationCenter defaultCenter] addObserverForName:kEMSReachabilityChangedNotification object:self.reachability queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *note) {
         [weakSelf.connectionChangeListener connectionChangedToNetworkStatus:[weakSelf connectionState] connectionStatus:[weakSelf isConnected]];
     }];
     [self.reachability startNotifier];

--- a/Core/ConnectionWatchdog/ThirdParty/EMSReachability.h
+++ b/Core/ConnectionWatchdog/ThirdParty/EMSReachability.h
@@ -15,13 +15,13 @@ typedef enum : NSInteger {
     NotReachable = 0,
     ReachableViaWiFi,
     ReachableViaWWAN
-} NetworkStatus;
+} EMSNetworkStatus;
 
 #pragma mark IPv6 Support
 //EMSReachability fully support IPv6.  For full details, see ReadMe.md.
 
 
-extern NSString *kReachabilityChangedNotification;
+extern NSString *kEMSReachabilityChangedNotification;
 
 
 @interface EMSReachability : NSObject
@@ -53,7 +53,7 @@ extern NSString *kReachabilityChangedNotification;
 
 - (void)stopNotifier;
 
-- (NetworkStatus)currentReachabilityStatus;
+- (EMSNetworkStatus)currentReachabilityStatus;
 
 /*!
  * WWAN may be available, but not active until a connection has been established. WiFi may require a connection for VPN on Demand.

--- a/Core/ConnectionWatchdog/ThirdParty/EMSReachability.m
+++ b/Core/ConnectionWatchdog/ThirdParty/EMSReachability.m
@@ -20,7 +20,7 @@
 //EMSReachability fully support IPv6.  For full details, see ReadMe.md.
 
 
-NSString *kReachabilityChangedNotification = @"kNetworkReachabilityChangedNotification";
+NSString *kEMSReachabilityChangedNotification = @"kEMSNetworkReachabilityChangedNotification";
 
 
 #pragma mark - Supporting functions
@@ -54,7 +54,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 
     EMSReachability *noteObject = (__bridge EMSReachability *) info;
     // Post a notification to notify the client that the network reachability changed.
-    [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification object:noteObject];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kEMSReachabilityChangedNotification object:noteObject];
 }
 
 
@@ -144,14 +144,14 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 
 #pragma mark - Network Flag Handling
 
-- (NetworkStatus)networkStatusForFlags:(SCNetworkReachabilityFlags)flags {
+- (EMSNetworkStatus)networkStatusForFlags:(SCNetworkReachabilityFlags)flags {
     PrintReachabilityFlags(flags, "networkStatusForFlags");
     if ((flags & kSCNetworkReachabilityFlagsReachable) == 0) {
         // The target host is not reachable.
         return NotReachable;
     }
 
-    NetworkStatus returnValue = NotReachable;
+    EMSNetworkStatus returnValue = NotReachable;
 
     if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0) {
         /*
@@ -197,9 +197,9 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 }
 
 
-- (NetworkStatus)currentReachabilityStatus {
+- (EMSNetworkStatus)currentReachabilityStatus {
     NSAssert(_reachabilityRef != NULL, @"currentNetworkStatus called with NULL SCNetworkReachabilityRef");
-    NetworkStatus returnValue = NotReachable;
+    EMSNetworkStatus returnValue = NotReachable;
     SCNetworkReachabilityFlags flags;
 
     if (SCNetworkReachabilityGetFlags(_reachabilityRef, &flags)) {

--- a/Core/Worker/EMSDefaultWorker.m
+++ b/Core/Worker/EMSDefaultWorker.m
@@ -95,7 +95,7 @@
 
 #pragma mark - EMSConnectionChangeListener
 
-- (void)connectionChangedToNetworkStatus:(NetworkStatus)networkStatus
+- (void)connectionChangedToNetworkStatus:(EMSNetworkStatus)networkStatus
                         connectionStatus:(BOOL)connected {
     if (connected) {
         [self run];


### PR DESCRIPTION
In case the project already contains `Reachability` it is not possible to integrate the SDK as a static library because it fails of duplicate symbols. This renames the symbols so they are unique to your SDK.